### PR TITLE
📄docs: 更新 overflow-wrap.mdx 和 word-break.mdx 中的示例文本，将中文示例替换为英文示例

### DIFF
--- a/src/docs/overflow-wrap.mdx
+++ b/src/docs/overflow-wrap.mdx
@@ -35,7 +35,7 @@ export const description = "用于控制溢出元素中文字换行的工具。"
 
 ```html
 <!-- [!code classes:wrap-break-word] -->
-<p class="wrap-break-word">在所有主要的英语字典中，最长的单词是...</p>
+<p class="wrap-break-word">The longest word in any of the major...</p>
 ```
 
 </Figure>
@@ -120,7 +120,7 @@ export const description = "用于控制溢出元素中文字换行的工具。"
 
 ```html
 <!-- [!code classes:wrap-normal] -->
-<p class="wrap-normal">在所有主要的英语字典中，最长的单词是...</p>
+<p class="wrap-normal">The longest word in any of the major...</p>
 ```
 
 </Figure>

--- a/src/docs/word-break.mdx
+++ b/src/docs/word-break.mdx
@@ -35,7 +35,7 @@ export const description = "用于控制元素中的单词换行的工具类。"
 
 ```html
 <!-- [!code classes:break-normal] -->
-<p class="break-normal">所有主要英语词典中最长的单词是...</p>
+<p class="break-normal">The longest word in any of the major...</p>
 ```
 
 </Figure>
@@ -59,7 +59,7 @@ export const description = "用于控制元素中的单词换行的工具类。"
 
 ```html
 <!-- [!code classes:break-all] -->
-<p class="break-all">所有主要英语词典中最长的单词是...</p>
+<p class="break-all">The longest word in any of the major...</p>
 ```
 
 </Figure>


### PR DESCRIPTION
### _**示例代码中文与预览效果英文不匹配，参照官方英文文档进行更正**_

![image](https://github.com/user-attachments/assets/d8181997-f003-4256-973c-5db99dc3f2b7)
![image](https://github.com/user-attachments/assets/1b4f424b-5251-42dd-a189-98e62f3030ce)
